### PR TITLE
Add missing use statement

### DIFF
--- a/src/Photographer.php
+++ b/src/Photographer.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace LoversOfBehat\ScreenshotExtension;
 
+use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Mink;
 
 /**


### PR DESCRIPTION
This prevents the `DriverException` to be caught, resulting in the following error if a step fails before a page has been accessed:

> Unable to access the response before visiting a page